### PR TITLE
Updated match timer

### DIFF
--- a/config/match-scouting.json
+++ b/config/match-scouting.json
@@ -1,8 +1,8 @@
 {
     "timing": {
-        "totalTime": 150000,
+        "totalTime": 153000,
         "timeTransitions": {
-            "149990": {
+            "152999": {
                 "layer": 1,
                 "displayText": "Auto",
                 "variables": {}


### PR DESCRIPTION
Updated totalTime to 153s from 150s and changed auto transition time to 15999 ms. Added 3 seconds to the total match timer to account for the transition from auto to teleop.