### PR TITLE
Layer reverse fix

### DIFF
--- a/src/scouting/executables/layer.js
+++ b/src/scouting/executables/layer.js
@@ -20,7 +20,7 @@ executables["layer"] = {
             button.element.style.display = "none"
         }
         previousLayers.pop();
-        previousLayers.pop();
+       
         console.log(previousLayers)
         for (let button of previousLayers[previousLayers.length-1]) {
               


### PR DESCRIPTION
Changed it to go back 1 layer after the undo button was clicked (assuming there was a layer change). Before, it would move back 2 layers, which was the bug. 