### PR TITLE
Update SPOT to indicate whether it is in demo mode or not. 

### DIFF
--- a/src/admin/public/css/style.css
+++ b/src/admin/public/css/style.css
@@ -207,6 +207,22 @@ body {
   transform: translateY(-50%);
 }
 
+.demo-label {
+  position: absolute;
+  background-color: var(--bg);
+  border-radius: 10px;
+  top: 0px;
+  left: 165px;
+  font: 2em/1em "Cairo";
+  padding: 0 6px;
+  transform: translateY(-50%);
+  color: crimson;
+}
+
+#small-demo-label {
+  color: crimson;
+}
+
 #match-list {
   height: 100%;
   width: 100%;

--- a/src/admin/public/css/ui-elements.css
+++ b/src/admin/public/css/ui-elements.css
@@ -105,6 +105,10 @@
   margin-top: 20px;
 }
 
+#demo-label {
+  color: crimson;
+}
+
 .popup {
   position: fixed;
   top: 0px;

--- a/src/admin/public/js/script.js
+++ b/src/admin/public/js/script.js
@@ -52,6 +52,24 @@ const scouters = {};
   }
 })();
 
+async function isDemo() {
+  const isDemo = await fetch("./api/isDemo").then((res) => res.json());
+
+  let demoItem = document.querySelector(".demo-label");
+  let demoItemSmol = document.querySelector("#small-demo-label");
+
+  if (isDemo == "true") {
+    demoItem.textContent = "DEMO";
+
+    demoItemSmol.textContent = "DEMO";
+  } else {
+    demoItem.textContent = "";
+    demoItemSmol.textContent = "";
+    demoItemSmol.;
+  }
+}
+isDemo();
+
 async function constructApp(accessCode) {
   await checkMigration();
 

--- a/src/admin/public/js/script.js
+++ b/src/admin/public/js/script.js
@@ -58,14 +58,13 @@ async function isDemo() {
   let demoItem = document.querySelector(".demo-label");
   let demoItemSmol = document.querySelector("#small-demo-label");
 
-  if (isDemo == "true") {
+  if (isDemo == true) {
     demoItem.textContent = "DEMO";
-
     demoItemSmol.textContent = "DEMO";
   } else {
     demoItem.textContent = "";
     demoItemSmol.textContent = "";
-    demoItemSmol.;
+    demoItemSmol.style.margin = "0";
   }
 }
 isDemo();

--- a/src/admin/routes/api.js
+++ b/src/admin/routes/api.js
@@ -28,6 +28,10 @@ router.get("/auth", (req, res) => {
   }
 });
 
+router.get("/isDemo", (req, res) => {
+  res.json(DEMO);
+});
+
 router.get("/scouters", (req, res) => {
   if (!DEMO) {
     if (req.headers.authorization === config.secrets.ACCESS_CODE) {

--- a/src/admin/views/index.ejs
+++ b/src/admin/views/index.ejs
@@ -68,6 +68,7 @@
       <div id="menu-icon-container">
         <i id="menu-icon" class="fas fa-angle-double-down"></i>
       </div>
+      <div id="small-demo-label">Demo</div>
       <a id="config" href="/setup">
         <i class="fas fa-cog"></i>
         <div>Edit Config</div>
@@ -91,6 +92,7 @@
         <div id="scouter-list"></div>
         <input type="button" id="start-scouting" value="Assign Scouters" />
         <div class="title">Scouters</div>
+        <div class="demo-label">Demo</div>
       </div>
       <div id="matches">
         <div class="title">Matches</div>

--- a/src/analysis/public/css/style.css
+++ b/src/analysis/public/css/style.css
@@ -235,6 +235,14 @@ body {
   text-align: center;
 }
 
+#demo-label {
+  font-size: 3em;
+  line-height: 1em;
+  margin-bottom: 12px;
+  color: crimson;
+}
+
+
 #welcome-subtext {
   font-size: 2.5rem;
   line-height: 1em;

--- a/src/analysis/public/js/script.js
+++ b/src/analysis/public/js/script.js
@@ -18,31 +18,30 @@ if ("serviceWorker" in navigator) {
 }
 
 /**
- * The function of the isDemo method is so that whenever SPOT is in demo mode, 
+ * The function of the isDemo method is so that whenever SPOT is in demo mode,
  *  it updates some text so that SPOT makes it very clear that it is in demo mode.
- * 
- * For future reference, it points to the span in analysis/views/index.ejs
- *  that has the id of 'demo-label'. As of November 4th 2025, it is on line 92 of that code.
+ *
  */
 async function isDemo() {
+  const isDemo = await fetch("./api/isDemo").then((res) => res.json()); // Check if in demo mode
 
-  config2 = await config; // Get config to check if in demo mode.
+  demoLabel = document.querySelector("#demo-label");
 
-  if (config2.DEMO == true) {
-    // Basically makes the demo text appear. 
-    document.querySelector("#demo-label").textContent = "DEMO"; 
-    document.querySelector("#demo-label").style.fontSize = "3em";
-    document.querySelector("#demo-label").style.lineHeight = "1em";
-    document.querySelector("#demo-label").style.marginBottom = "12px";
+  if (isDemo) {
+    // Basically makes the demo text appear.
+    demoLabel.textContent = "DEMO";
+    demoLabel.style.fontSize = "3em";
+    demoLabel.style.lineHeight = "1em";
+    demoLabel.style.marginBottom = "12px";
   } else {
     // Basically makes the demo text disappear.
-    document.querySelector("#demo-label").textContent = "";
-    document.querySelector("#demo-label").style.fontSize = "0em";
-    document.querySelector("#demo-label").style.lineHeight = "0em";
-    document.querySelector("#demo-label").style.marginBottom = "0px";
+    demoLabel.textContent = "";
+    demoLabel.style.fontSize = "0em";
+    demoLabel.style.lineHeight = "0em";
+    demoLabel.style.marginBottom = "0px";
   }
 }
-isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it. 
+isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it.
 
 function getSelectedEvent() {
   // Parse the query string to check for the 'event' parameter.

--- a/src/analysis/public/js/script.js
+++ b/src/analysis/public/js/script.js
@@ -17,6 +17,33 @@ if ("serviceWorker" in navigator) {
   });
 }
 
+/**
+ * The function of the isDemo method is so that whenever SPOT is in demo mode, 
+ *  it updates some text so that SPOT makes it very clear that it is in demo mode.
+ * 
+ * For future reference, it points to the span in analysis/views/index.ejs
+ *  that has the id of 'demo-label'. As of November 4th 2025, it is on line 92 of that code.
+ */
+async function isDemo() {
+
+  config2 = await config; // Get config to check if in demo mode.
+
+  if (config2.DEMO == true) {
+    // Basically makes the demo text appear. 
+    document.querySelector("#demo-label").textContent = "DEMO"; 
+    document.querySelector("#demo-label").style.fontSize = "3em";
+    document.querySelector("#demo-label").style.lineHeight = "1em";
+    document.querySelector("#demo-label").style.marginBottom = "12px";
+  } else {
+    // Basically makes the demo text disappear.
+    document.querySelector("#demo-label").textContent = "";
+    document.querySelector("#demo-label").style.fontSize = "0em";
+    document.querySelector("#demo-label").style.lineHeight = "0em";
+    document.querySelector("#demo-label").style.marginBottom = "0px";
+  }
+}
+isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it. 
+
 function getSelectedEvent() {
   // Parse the query string to check for the 'event' parameter.
   const queryString = window.location.search;

--- a/src/analysis/routes/api.js
+++ b/src/analysis/routes/api.js
@@ -17,6 +17,10 @@ router.get("/dataset", async (req, res) => {
   );
 });
 
+router.get("/isDemo", (req, res) => {
+  res.json(config.DEMO);
+});
+
 router.get("/dataset/:eventID", async (req, res) => {
   res.json(
     await TeamMatchPerformance.find({ eventNumber: req.params.eventID })

--- a/src/analysis/views/index.ejs
+++ b/src/analysis/views/index.ejs
@@ -89,6 +89,7 @@
 		<div id="dashboard">
 			<div id="welcome" class="visible">
 				<div id="welcome-text">SPOT Analysis</div>
+				<div id="demo-label">DEMO</div>
 				<div id="welcome-subtext">Select a Team</div>
 			</div>
 			<div id="team-view">

--- a/src/scouting/public/css/landing.css
+++ b/src/scouting/public/css/landing.css
@@ -160,6 +160,13 @@
   margin-bottom: 12px;
 }
 
+#landing .demo-label {
+  font-size: 3em;
+  line-height: 1em;
+  margin-bottom: 12px;
+  color: crimson;
+}
+
 #landing .logo {
   height: 90vmin;
   position: absolute;

--- a/src/scouting/public/js/landing.js
+++ b/src/scouting/public/js/landing.js
@@ -48,6 +48,23 @@ async function signOut() {
   spinner.classList.remove("visible");
 }
 
+async function isDemo() {
+  config2 = await config;
+  console.log(config2.DEMO);
+  if (config2.DEMO == "true") {
+    document.querySelector(".demo-label").textContent = "DEMO";
+    document.querySelector(".demo-label").style.fontSize = "3em";
+    document.querySelector(".demo-label").style.lineHeight = "1em";
+    document.querySelector(".demo-label").style.marginBottom = "12px";
+  } else {
+    document.querySelector(".demo-label").textContent = "";
+    document.querySelector(".demo-label").style.fontSize = "0em";
+    document.querySelector(".demo-label").style.lineHeight = "0em";
+    document.querySelector(".demo-label").style.marginBottom = "0px";
+  }
+}
+isDemo();
+
 async function userChanged(user) {
   if (auth2.isSignedIn.get()) {
     const verification = await verify(user);

--- a/src/scouting/public/js/landing.js
+++ b/src/scouting/public/js/landing.js
@@ -48,22 +48,32 @@ async function signOut() {
   spinner.classList.remove("visible");
 }
 
+/**
+ * The function of the isDemo method is so that whenever SPOT is in demo mode, 
+ *  it updates some text so that SPOT makes it very clear that it is in demo mode.
+ * 
+ * For future reference, it points to the span in scouting/views/pages/landing.ejs
+ *  that has the class of 'demo-label'. As of November 4th 2025, it is on line 24 of that code.
+ */
 async function isDemo() {
-  config2 = await config;
-  console.log(config2.DEMO);
-  if (config2.DEMO == "true") {
-    document.querySelector(".demo-label").textContent = "DEMO";
+
+  config2 = await config; // Get config to check if in demo mode.
+
+  if (config2.DEMO == true) {
+    // Basically makes the demo text appear. 
+    document.querySelector(".demo-label").textContent = "DEMO"; 
     document.querySelector(".demo-label").style.fontSize = "3em";
     document.querySelector(".demo-label").style.lineHeight = "1em";
     document.querySelector(".demo-label").style.marginBottom = "12px";
   } else {
+    // Basically makes the demo text disappear.
     document.querySelector(".demo-label").textContent = "";
     document.querySelector(".demo-label").style.fontSize = "0em";
     document.querySelector(".demo-label").style.lineHeight = "0em";
     document.querySelector(".demo-label").style.marginBottom = "0px";
   }
 }
-isDemo();
+isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it. 
 
 async function userChanged(user) {
   if (auth2.isSignedIn.get()) {

--- a/src/scouting/public/js/landing.js
+++ b/src/scouting/public/js/landing.js
@@ -49,31 +49,29 @@ async function signOut() {
 }
 
 /**
- * The function of the isDemo method is so that whenever SPOT is in demo mode, 
+ * The function of the isDemo method is so that whenever SPOT is in demo mode,
  *  it updates some text so that SPOT makes it very clear that it is in demo mode.
- * 
- * For future reference, it points to the span in scouting/views/pages/landing.ejs
- *  that has the class of 'demo-label'. As of November 4th 2025, it is on line 24 of that code.
  */
 async function isDemo() {
+  const isDemo = await fetch("./auth/isDemo").then((res) => res.json()); // Check if in demo mode
 
-  config2 = await config; // Get config to check if in demo mode.
+  demoLabel = document.querySelector(".demo-label");
 
-  if (config2.DEMO == true) {
-    // Basically makes the demo text appear. 
-    document.querySelector(".demo-label").textContent = "DEMO"; 
-    document.querySelector(".demo-label").style.fontSize = "3em";
-    document.querySelector(".demo-label").style.lineHeight = "1em";
-    document.querySelector(".demo-label").style.marginBottom = "12px";
+  if (isDemo == true) {
+    // Basically makes the demo text appear.
+    demoLabel.textContent = "DEMO";
+    demoLabel.style.fontSize = "3em";
+    demoLabel.style.lineHeight = "1em";
+    demoLabel.style.marginBottom = "12px";
   } else {
     // Basically makes the demo text disappear.
-    document.querySelector(".demo-label").textContent = "";
-    document.querySelector(".demo-label").style.fontSize = "0em";
-    document.querySelector(".demo-label").style.lineHeight = "0em";
-    document.querySelector(".demo-label").style.marginBottom = "0px";
+    demoLabel.textContent = "";
+    demoLabel.style.fontSize = "0em";
+    demoLabel.style.lineHeight = "0em";
+    demoLabel.style.marginBottom = "0px";
   }
 }
-isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it. 
+isDemo(); // Probably somewhere better to put this, but it works so I do not care to find it.
 
 async function userChanged(user) {
   if (auth2.isSignedIn.get()) {

--- a/src/scouting/routes/auth.js
+++ b/src/scouting/routes/auth.js
@@ -14,6 +14,10 @@ router.get("/verify", async (req, res) => {
   }
 });
 
+router.get("/isDemo", (req, res) => {
+  res.json(config.DEMO);
+});
+
 async function verifyUser(token) {
   const ticket = await oAuth2Client
     .verifyIdToken({

--- a/src/scouting/views/index.ejs
+++ b/src/scouting/views/index.ejs
@@ -53,6 +53,8 @@
 		<div class="last-actions" id="last-actions"></div>
 	</div>
 
+
+
     <% for (let filename of pages) { %>
         <div id=<%=filename.replace(".ejs","")%> class="page <%= filename === landingPage + ".ejs" ? "visible" : ""%>"><%- include(`pages/${filename}`) %></div>
     <% } %>

--- a/src/scouting/views/pages/landing.ejs
+++ b/src/scouting/views/pages/landing.ejs
@@ -21,6 +21,7 @@
       />
     </div>
     <span class="sign-in-text">SPOT</span>
+    <span class="demo-label">DEMO</span>
     <div class="auth-buttons">
       <div class="google active">
         <i class="fab fa-google"></i>


### PR DESCRIPTION
Add a permanent demo label to the landing page, admin page and analysis page. While technically always there, the label just gets hidden (completely) if it is not in demo mode. 