### PR TITLE
Use the createConnection method to enable multiple connections.

### DIFF
--- a/src/setup/routes/api.js
+++ b/src/setup/routes/api.js
@@ -144,7 +144,7 @@ router.post("/config", async (req, res) => {
   if (!REQUIRE_ACCESS_CODE || req.body.ACCESS_CODE == ACCESS_CODE) {
     //verify mongodb url
     try {
-      await mongoose.connect(config.secrets.DATABASE_URL, {
+      await mongoose.createConnection(config.secrets.DATABASE_URL, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
       }); //try connecting to mongodb server


### PR DESCRIPTION
Mongoose can only have one default connection at a time. Therefore, when testing a new DATABASE_URL, we need to use the createConnection method instead of the connect method so that a new connection is established since the default already exists and may refer to a different cluster or database.