### PR TITLE
Add visual feedback for when buttons pressed

### DIFF
--- a/src/scouting/public/css/match-scouting.css
+++ b/src/scouting/public/css/match-scouting.css
@@ -35,12 +35,31 @@
   padding: 5px;
   box-shadow: 0 0 8px 0px #838383;
   transition:
-    0.2s border,
-    0.2s box-shadow;
+    0.08s filter,
+    0.08s transform,
+    0.12s border,
+    0.12s box-shadow;
 }
 #match-scouting .grid-button:active {
-  box-shadow: 0 0 12px 0px #222222;
-  font-size: 3.3vw;
+  filter: brightness(0.9);
+  transform: translateY(1px);
+  border: 5px solid rgba(76, 136, 3, 0.9);
+  outline: 5px solid rgba(76, 136, 3, 0.9);
+  outline-offset: -2px;
+  box-shadow:
+    0 0 14px 1px rgba(255, 246, 193, 0.65),
+    inset 0 0 0 999px rgba(0, 0, 0, 0.08);
+}
+
+#match-scouting .grid-button.pressed {
+  filter: brightness(0.9);
+  transform: translateY(1px);
+  border: 5px solid rgba(76, 136, 3, 0.95);
+  outline: 5px solid rgba(76, 136, 3, 0.9);
+  outline-offset: -2px;
+  box-shadow:
+    0 0 14px 1px rgba(255, 246, 193, 0.65),
+    inset 0 0 0 999px rgba(0, 0, 0, 0.08);
 }
 
 #last-actions {

--- a/src/scouting/public/js/match-scouting.js
+++ b/src/scouting/public/js/match-scouting.js
@@ -229,6 +229,27 @@ let previousLayers = [];
     }
   }
 
+  function addPressFeedback(buttonElement) {
+    let clearPressedTimeout;
+
+    const setPressed = () => {
+      clearTimeout(clearPressedTimeout);
+      buttonElement.classList.add("pressed");
+    };
+
+    const clearPressed = () => {
+      clearTimeout(clearPressedTimeout);
+      clearPressedTimeout = setTimeout(() => {
+        buttonElement.classList.remove("pressed");
+      }, 90);
+    };
+
+    buttonElement.addEventListener("pointerdown", setPressed);
+    buttonElement.addEventListener("pointerup", clearPressed);
+    buttonElement.addEventListener("pointerleave", clearPressed);
+    buttonElement.addEventListener("pointercancel", clearPressed);
+  }
+
   const buttonBuilders = {
     //an object to give buttons type specific things, button type: function (button)
     action: (button) => {
@@ -545,6 +566,7 @@ let previousLayers = [];
       button.element.innerText = button.displayText || button.id;
       button.element.classList.add("grid-button", ...button.class.split(" "));
       button.element.style.gridArea = button.gridArea.join(" / ");
+      addPressFeedback(button.element);
 
       //apply type to button+
       buttonBuilders[button.type](button);


### PR DESCRIPTION
Frequently requested in the Midwest Scouter feedback form. Added a function in match-scouting.js that looks for event listeners to modify the CSS properties that were added to provide visual feedback to the scouters when a button is pressed. The button color gets "darker" and highlighted with a dark green border when it is pressed. 