### PR TITLE
Disable Buttons When A-Stop is pressed

### DIFF
--- a/src/analysis/public/js/filterTeams.js
+++ b/src/analysis/public/js/filterTeams.js
@@ -245,11 +245,11 @@ function collectFilteredTeams() {
     return teamMatchesFilter(team);
   });
   // Debug logging
-  console.log("All Teams:", allTeamsArray);
-  console.log("Selected Actions:", filterTeamState.selectedActions);
-  console.log("Selected Ratings:", filterTeamState.selectedRatings);
-  console.log("number of teams matching filter:", filteredTeams.length);
-  console.log("Filtered Teams:", filteredTeams);
+  // console.log("All Teams:", allTeamsArray);
+  // console.log("Selected Actions:", filterTeamState.selectedActions);
+  // console.log("Selected Ratings:", filterTeamState.selectedRatings);
+  // console.log("number of teams matching filter:", filteredTeams.length);
+  // console.log("Filtered Teams:", filteredTeams);
   return filteredTeams;
 }
 

--- a/src/scouting/public/css/match-scouting.css
+++ b/src/scouting/public/css/match-scouting.css
@@ -187,6 +187,33 @@
   pointer-events: none;
 }
 
+.a-stop-lock-banner {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(90vw, 54rem);
+  max-width: min(90vw, 54rem);
+  padding: 0.9rem 1.2rem;
+  box-sizing: border-box;
+  border-radius: var(--border-radius, 16px);
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  background: rgba(153, 31, 31, 0.93);
+  color: #fff;
+  font-size: max(1.6vw, 16px);
+  line-height: 1.25;
+  text-align: center;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+}
+
+.a-stop-lock-banner[hidden] {
+  display: none;
+}
+
 .click-indicator {
   position: absolute;
   width: 20px;

--- a/src/scouting/public/js/match-scouting.js
+++ b/src/scouting/public/js/match-scouting.js
@@ -31,12 +31,15 @@ let previousLayers = [];
   if (teleopTransitionTimes.length > 0) {
     teleopTime = teleopTransitionTimes[0];
   }
+  // This is the auto window cutoff; it follows the configured teleop transition.
+  const autoPhaseEndTime = 140000;
   let endgameTime = 30000;
   let shiftSwitchInterval = 25000;
   let timerActive = false;
   let currentShift = ""; // "active" | "inactive"
   let lastShiftSwitchTime = teleopTime;
   let shiftButtonPressed = false;
+  let aStopLockActive = false;
 
   // shift counters
   let activeShiftCount = 0;
@@ -55,6 +58,14 @@ let previousLayers = [];
   }
   //create grid
   const grid = document.querySelector("#match-scouting .button-grid");
+  const matchScoutingRoot = document.querySelector("#match-scouting");
+  // Visible warning shown while the temporary A-Stop lock is active.
+  const aStopLockBanner = document.createElement("div");
+  aStopLockBanner.className = "a-stop-lock-banner";
+  aStopLockBanner.innerText =
+    "You pressed the A-Stop button, all the buttons will be disabled until Auto ends. If this is a mistake then press the Undo button";
+  aStopLockBanner.hidden = true;
+  matchScoutingRoot.appendChild(aStopLockBanner);
   grid.style.gridTemplateColumns = `repeat(${matchScoutingConfig.layout.gridColumns}, 1fr)`;
   grid.style.gridTemplateRows = `repeat(${matchScoutingConfig.layout.gridRows}, 1fr)`;
 
@@ -84,10 +95,39 @@ let previousLayers = [];
   //build buttons
   const layers = deepClone(matchScoutingConfig.layout.layers);
   const buttons = layers.flat();
+  // Keep Undo and match-control available so the operator can recover.
+  const aStopExemptTypes = new Set(["undo", "match-control"]);
+
   function findLayerIndexByButtonId(buttonId) {
     return layers.findIndex((layer) =>
       layer.some((button) => (button.configId || button.id) === buttonId),
     );
+  }
+
+  // Layouts can rename the A-Stop button, so detect it by id text.
+  function isAStopButton(button) {
+    return /astop/i.test(button.configId || button.id || "");
+  }
+
+  // Sync the disabled state and viewer-facing banner with the current timer.
+  function updateAStopLockState() {
+    const locked = aStopLockActive && time > autoPhaseEndTime;
+
+    for (const button of buttons) {
+      if (aStopExemptTypes.has(button.type)) {
+        button.element.classList.remove("disabled");
+        continue;
+      }
+
+      button.element.classList.toggle("disabled", locked);
+    }
+
+    matchScoutingRoot.classList.toggle("a-stop-active", locked);
+    aStopLockBanner.hidden = !locked;
+
+    if (!locked && aStopLockActive && time <= autoPhaseEndTime) {
+      aStopLockActive = false;
+    }
   }
 
   function findTeleopLayerIndex() {
@@ -254,6 +294,11 @@ let previousLayers = [];
     //an object to give buttons type specific things, button type: function (button)
     action: (button) => {
       button.element.addEventListener("click", () => {
+        // Pressing A-Stop during auto enables the temporary lock until auto ends.
+        if (isAStopButton(button) && time > autoPhaseEndTime) {
+          aStopLockActive = true;
+        }
+
         let shift = camelCase(displayTextWithShift);
         let actionId = `${shift.replace(" ", "")}${button.id}`;
 
@@ -265,6 +310,7 @@ let previousLayers = [];
 
         doExecutables(button);
         updateLastAction();
+        updateAStopLockState();
       });
     },
     undo: (button) => {
@@ -293,6 +339,8 @@ let previousLayers = [];
            */
           if (undoneButton.type === "match-control") {
             time = matchScoutingConfig.timing.totalTime; //reset timer
+            // Resetting the match also clears any active A-Stop lock.
+            aStopLockActive = false;
             ScoutingSync.updateState({
               status: ScoutingSync.SCOUTER_STATUS.WAITING,
             }); //tell the server that you are now waiting to start
@@ -300,6 +348,11 @@ let previousLayers = [];
             undoneButton.element.innerText = "Start Match";
             timerActive = false;
             showLayer(0);
+          }
+
+          if (undoneButton && isAStopButton(undoneButton)) {
+            // Undoing the A-Stop action restores normal button interaction immediately.
+            aStopLockActive = false;
           }
 
           /*
@@ -349,6 +402,7 @@ let previousLayers = [];
          */
         doExecutables(button, time);
         updateLastAction();
+        updateAStopLockState();
       });
     },
 
@@ -433,6 +487,9 @@ let previousLayers = [];
 
         if (timerActive) return;
 
+        aStopLockActive = false;
+        updateAStopLockState();
+
         actionQueue.push({
           //create a temporary action queue so you can undo it
           id: button.id,
@@ -502,6 +559,7 @@ let previousLayers = [];
           }
           time = matchScoutingConfig.timing.totalTime - (Date.now() - start);
           window.currentTime = time; // Keep window.currentTime in sync
+          updateAStopLockState();
           let elapsedSinceSwitch = Math.abs(time - lastShiftSwitchTime);
           // Handle shift switching during teleop (between teleopTime and endgameTime)
           // Only switch if a shift button has been pressed

--- a/src/scouting/public/js/match-scouting.js
+++ b/src/scouting/public/js/match-scouting.js
@@ -104,9 +104,21 @@ let previousLayers = [];
     );
   }
 
-  // Layouts can rename the A-Stop button, so detect it by id text.
+  // Detect it by either label or id text so that it works even if the button name/Id is slightly changed or if the button is configured with a custom display text.
   function isAStopButton(button) {
-    return /astop/i.test(button.configId || button.id || "");
+    const buttonIdentifiers = [
+      button.originalDisplayText,
+      button.displayText,
+      button.configId,
+      button.id,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return buttonIdentifiers
+      .toLowerCase()
+      .replace(/[\s-]/g, "")
+      .includes("astop");
   }
 
   // Sync the disabled state and viewer-facing banner with the current timer.

--- a/src/scouting/views/pages/landing.ejs
+++ b/src/scouting/views/pages/landing.ejs
@@ -89,7 +89,7 @@
     </div>
   </div>
 
-  <div id="v-string" class="versionString">2026 v5.1.0</div>
+  <div id="v-string" class="versionString">2026 v5.2.0</div>
 
   <script src="https://apis.google.com/js/platform.js"></script>
   <script src="/js/landing.js"></script>


### PR DESCRIPTION
The code essentially disables all the buttons (with the exception of the undo and match-control buttons) when the A-Stop button is pressed until the Auto Period ends. It also lets the users know that the buttons are disabled through a text description. 

Some other miscellaneous changes, such as updating the version text at the landing page from v5.1 to v5.2 and commenting out console.log messages for the filterTeams.js, which were added for debugging purposes. 