### PR TITLE
Add firefox support to the launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,10 +12,17 @@
     {
       "type": "chrome",
       "request": "launch",
-      "name": "SPOT Client",
+      "name": "SPOT Client Chrome",
       "url": "http://localhost:8080",
       "webRoot": "${workspaceFolder}/src/analysis/public",
       "outputCapture": "std"
+    },
+    {
+      "type": "firefox",
+      "request": "launch",
+      "name": "SPOT Client Firefox",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}/src/analysis/public"
     }
   ]
 }


### PR DESCRIPTION
Add a option in the launch.json to open the spot client in firefox. Also update the chrome name to be "SPOT Client Chrome" and have the firefox name be "SPOT Client Firefox". 